### PR TITLE
Adding tertiary metrics to the workflow

### DIFF
--- a/score.cwl
+++ b/score.cwl
@@ -8,7 +8,7 @@ baseCommand: [Rscript, /score.R]
 
 hints:
   DockerRequirement:
-    dockerPull: docker.synapse.org/syn18404606/scoring:v1
+    dockerPull: docker.synapse.org/syn18404606/scoring:v2
 
 inputs:
   - id: inputfile

--- a/workflow.cwl
+++ b/workflow.cwl
@@ -421,7 +421,7 @@ steps:
       - id: results
         source: "#scoring/results"
       - id: private_annotations
-        default: ["tertiary_metric", "tertiary_metric_value"]
+        default: ["tertiary_metric", "tertiary_metric_score"]
     out: []
 
   annotate_submission_with_output:

--- a/workflow.cwl
+++ b/workflow.cwl
@@ -411,16 +411,18 @@ steps:
     out:
       - id: results
       
-  # score_email:
-  #   run: https://raw.githubusercontent.com/Sage-Bionetworks/ChallengeWorkflowTemplates/v3.0/cwl/score_email.cwl
-  #   in:
-  #     - id: submissionid
-  #       source: "#submissionId"
-  #     - id: synapse_config
-  #       source: "#synapseConfig"
-  #     - id: results
-  #       source: "#scoring/results"
-  #   out: []
+  score_email:
+    run: https://raw.githubusercontent.com/Sage-Bionetworks/ChallengeWorkflowTemplates/v3.0/cwl/score_email.cwl
+    in:
+      - id: submissionid
+        source: "#submissionId"
+      - id: synapse_config
+        source: "#synapseConfig"
+      - id: results
+        source: "#scoring/results"
+      - id: private_annotations
+        default: ["tertiary_metric", "tertiary_metric_value"]
+    out: []
 
   annotate_submission_with_output:
     run: https://raw.githubusercontent.com/Sage-Bionetworks/ChallengeWorkflowTemplates/v3.0/cwl/annotate_submission.cwl

--- a/workflow.cwl
+++ b/workflow.cwl
@@ -411,18 +411,18 @@ steps:
     out:
       - id: results
       
-  score_email:
-    run: https://raw.githubusercontent.com/Sage-Bionetworks/ChallengeWorkflowTemplates/v3.0/cwl/score_email.cwl
-    in:
-      - id: submissionid
-        source: "#submissionId"
-      - id: synapse_config
-        source: "#synapseConfig"
-      - id: results
-        source: "#scoring/results"
-      - id: private_annotations
-        default: ["tertiary_metric", "tertiary_metric_score"]
-    out: []
+  # score_email:
+  #   run: https://raw.githubusercontent.com/Sage-Bionetworks/ChallengeWorkflowTemplates/v3.0/cwl/score_email.cwl
+  #   in:
+  #     - id: submissionid
+  #       source: "#submissionId"
+  #     - id: synapse_config
+  #       source: "#synapseConfig"
+  #     - id: results
+  #       source: "#scoring/results"
+  #     - id: private_annotations
+  #       default: ["tertiary_metric", "tertiary_metric_value"]
+  #   out: []
 
   annotate_submission_with_output:
     run: https://raw.githubusercontent.com/Sage-Bionetworks/ChallengeWorkflowTemplates/v3.0/cwl/annotate_submission.cwl


### PR DESCRIPTION
Per Mike's request:

_add the C.index / AUC for the Chemo arm_

Scoring code has been updated accordingly, to `v2`.

These scores should not returned to the participants during the Validation Queue, so this has also been implemented into the `score_email` step (which is still commented out at this time).