### PR TITLE
Add in submission number to scoring step

### DIFF
--- a/determine_submission_number.cwl
+++ b/determine_submission_number.cwl
@@ -8,7 +8,7 @@ baseCommand: [python3, get_submission_number.py]
 
 hints:
   DockerRequirement:
-    dockerPull: sagebionetworks/synapsepythonclient:v2.2.0
+    dockerPull: sagebionetworks/synapsepythonclient:v2.2.2
 
 inputs:
   - id: submission_id

--- a/determine_submission_number.cwl
+++ b/determine_submission_number.cwl
@@ -17,7 +17,7 @@ inputs:
       prefix: -s
 
   - id: queue
-    type: int
+    type: string
     inputBinding:
       prefix: -e
 

--- a/determine_submission_number.cwl
+++ b/determine_submission_number.cwl
@@ -1,0 +1,72 @@
+#!/usr/bin/env cwl-runner
+#
+# Get submission number
+#
+cwlVersion: v1.0
+class: CommandLineTool
+baseCommand: [python3, get_submission_number.py]
+
+hints:
+  DockerRequirement:
+    dockerPull: sagebionetworks/synapsepythonclient:v2.2.0
+
+inputs:
+  - id: submission_id
+    type: int
+    inputBinding:
+      prefix: -s
+
+  - id: queue
+    type: int
+    inputBinding:
+      prefix: -e
+
+  - id: submission_view
+    type: string
+    inputBinding:
+      prefix: -v
+
+  - id: synapse_config
+    type: File
+    inputBinding:
+      prefix: -c
+
+requirements:
+  - class: InlineJavascriptRequirement
+  - class: InitialWorkDirRequirement
+    listing:
+      - entryname: get_submission_number.py
+        entry: |
+          #!/usr/bin/env python
+          import argparse
+          
+          import synapseclient
+          
+          parser = argparse.ArgumentParser()
+          parser.add_argument("-s", "--submission_id", required=True, help="Submission ID")
+          parser.add_argument("-e", "--evaluation_id", required=True, help="Evaluation ID")
+          parser.add_argument("-v", "--submission_view", required=True, help="Submission View")
+          parser.add_argument("-c", "--config", required=True, help="Config file with Synapese credentials")
+
+          args = parser.parse_args()
+          syn = synapseclient.Synapse(configPath=args.config)
+          syn.login(silent=True)
+          
+          submission = syn.getSubmission(args.submission_id, downloadFile=False)
+          submitter = submission.get("teamId", submission["userId"])
+          
+          query = (f"SELECT count(*) FROM {args.submission_view} "
+                   f"WHERE evaluationid = {args.evaluation_id} "
+                   f"AND submitterid = {submitter} AND status = 'ACCEPTED'")
+          submissions_count = next(syn.tableQuery(query, resultsAs="rowset"))
+
+          with open("output.txt", "w") as o:
+            o.write(str(submissions_count.get("values")[0]))
+
+outputs:
+  submission_number:
+    type: int
+    outputBinding:
+      glob: output.txt
+      loadContents: true
+      outputEval: $(parseInt(self[0].contents))

--- a/score.cwl
+++ b/score.cwl
@@ -33,7 +33,7 @@ inputs:
       prefix: -q
   
   - id: submission_number
-    type: int?
+    type: int
     inputBinding:
       prefix: -s
 

--- a/score.cwl
+++ b/score.cwl
@@ -8,7 +8,7 @@ baseCommand: [Rscript, /score.R]
 
 hints:
   DockerRequirement:
-    dockerPull: docker.synapse.org/syn18404606/scoring:v2
+    dockerPull: docker.synapse.org/syn18404606/scoring:v3
 
 inputs:
   - id: inputfile
@@ -31,6 +31,11 @@ inputs:
     type: string?
     inputBinding:
       prefix: -q
+  
+  - id: submission_number
+    type: int?
+    inputBinding:
+      prefix: -s
 
   - id: check_validation_finished
     type: boolean?

--- a/validate.cwl
+++ b/validate.cwl
@@ -8,7 +8,7 @@ baseCommand: [python3, validate.py]
 
 hints:
   DockerRequirement:
-    dockerPull: sagebionetworks/synapsepythonclient:v2.2.0
+    dockerPull: sagebionetworks/synapsepythonclient:v2.2.2
 
 inputs:
 

--- a/workflow.cwl
+++ b/workflow.cwl
@@ -397,13 +397,19 @@ steps:
     out:
       - id: question
 
-  # determine_submission_number:
-  #   run: determine_submission.cwl
-  #   in:
-  #     - id: queue
-  #       source: "#get_docker_submission/evaluation_id"
-  #   out:
-  #     - id: submission_number
+  determine_submission_number:
+    run: determine_submission.cwl
+    in:
+      - id: submission_id
+        source: "#submissionId"
+      - id: synapse_config
+        source: "#synapseConfig"
+      - id: queue
+        source: "#get_docker_submission/evaluation_id"
+      - id: submission_view
+        valueFrom: "syn22340111"
+    out:
+      - id: submission_number
 
   scoring:
     run: score.cwl
@@ -417,8 +423,7 @@ steps:
       - id: question
         source: "#determine_question/question"
       - id: submission_number
-        default: 0
-        # source: "#determine_submission_number/submission_number"
+        source: "#determine_submission_number/submission_number"
     out:
       - id: results
       

--- a/workflow.cwl
+++ b/workflow.cwl
@@ -422,18 +422,18 @@ steps:
     out:
       - id: results
       
-  score_email:
-    run: https://raw.githubusercontent.com/Sage-Bionetworks/ChallengeWorkflowTemplates/v3.0/cwl/score_email.cwl
-    in:
-      - id: submissionid
-        source: "#submissionId"
-      - id: synapse_config
-        source: "#synapseConfig"
-      - id: results
-        source: "#scoring/results"
-      - id: private_annotations
-        default: ["primary_bootstrapped", "secondary_bootstrapped", "tertiary_bootstrapped", "tertiary_metric", "tertiary_metric_value"]
-    out: []
+  # score_email:
+  #   run: https://raw.githubusercontent.com/Sage-Bionetworks/ChallengeWorkflowTemplates/v3.0/cwl/score_email.cwl
+  #   in:
+  #     - id: submissionid
+  #       source: "#submissionId"
+  #     - id: synapse_config
+  #       source: "#synapseConfig"
+  #     - id: results
+  #       source: "#scoring/results"
+  #     - id: private_annotations
+  #       default: ["primary_bootstrapped", "secondary_bootstrapped", "tertiary_bootstrapped", "tertiary_metric", "tertiary_metric_value"]
+  #   out: []
 
   annotate_submission_with_output:
     run: https://raw.githubusercontent.com/Sage-Bionetworks/ChallengeWorkflowTemplates/v3.0/cwl/annotate_submission.cwl

--- a/workflow.cwl
+++ b/workflow.cwl
@@ -397,6 +397,14 @@ steps:
     out:
       - id: question
 
+  # determine_submission_number:
+  #   run: determine_submission.cwl
+  #   in:
+  #     - id: queue
+  #       source: "#get_docker_submission/evaluation_id"
+  #   out:
+  #     - id: submission_number
+
   scoring:
     run: score.cwl
     in:
@@ -408,21 +416,24 @@ steps:
         source: "#check_status_real/finished"
       - id: question
         source: "#determine_question/question"
+      - id: submission_number
+        default: 0
+        # source: "#determine_submission_number/submission_number"
     out:
       - id: results
       
-  # score_email:
-  #   run: https://raw.githubusercontent.com/Sage-Bionetworks/ChallengeWorkflowTemplates/v3.0/cwl/score_email.cwl
-  #   in:
-  #     - id: submissionid
-  #       source: "#submissionId"
-  #     - id: synapse_config
-  #       source: "#synapseConfig"
-  #     - id: results
-  #       source: "#scoring/results"
-  #     - id: private_annotations
-  #       default: ["tertiary_metric", "tertiary_metric_value"]
-  #   out: []
+  score_email:
+    run: https://raw.githubusercontent.com/Sage-Bionetworks/ChallengeWorkflowTemplates/v3.0/cwl/score_email.cwl
+    in:
+      - id: submissionid
+        source: "#submissionId"
+      - id: synapse_config
+        source: "#synapseConfig"
+      - id: results
+        source: "#scoring/results"
+      - id: private_annotations
+        default: ["primary_bootstrapped", "secondary_bootstrapped", "tertiary_bootstrapped", "tertiary_metric", "tertiary_metric_value"]
+    out: []
 
   annotate_submission_with_output:
     run: https://raw.githubusercontent.com/Sage-Bionetworks/ChallengeWorkflowTemplates/v3.0/cwl/annotate_submission.cwl

--- a/workflow.cwl
+++ b/workflow.cwl
@@ -398,7 +398,7 @@ steps:
       - id: question
 
   determine_submission_number:
-    run: determine_submission.cwl
+    run: determine_submission_number.cwl
     in:
       - id: submission_id
         source: "#submissionId"


### PR DESCRIPTION
The proposed new submission limit for the Validation Phase is now 5 instead of 2. To help prevent overfitting, we are going to return the average of 5-10 bootstrapped scores, in which the `seed` number is dependent on the submitter's current submission number.

For example, if this is the submitter's first submission to the Validation Phase, their seed number would be `1`. Whereas if the submitter already has one successful submission for the phase, then their next submission will have a seed number of `2`.

Participants should still only receive their primary and secondary scores; the tertiary metrics and bootstrapped scores are for the admins and organizers only.