### PR TITLE
update wf to use new validation dataset

### DIFF
--- a/workflow.cwl
+++ b/workflow.cwl
@@ -287,7 +287,7 @@ steps:
       - id: store
         default: false
       - id: input_dir
-        valueFrom: "/home01/centos/challenge_data/CM_026_formatted_for_Challenge"
+        valueFrom: "/home01/centos/challenge_data/CM_227_formatted_for_Challenge"
       - id: docker_script
         default:
           class: File


### PR DESCRIPTION
This PR will make it so the workflow points at the new validation dataset (CM_227) during submission evaluations.

TODO:
- [ ] start logging container
- [ ] start helper container (where goldstandard will be mounted)